### PR TITLE
Add ClusterRole permissions for Homepage reading IngressRoutes

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: Chart for benphelps homepage
 icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
-version: 1.1.1
+version: 1.2.0
 appVersion: v0.6.10
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage

--- a/charts/homepage/templates/rbac.yaml
+++ b/charts/homepage/templates/rbac.yaml
@@ -42,6 +42,13 @@ rules:
       - get
       - list
   - apiGroups:
+      - traefik.containo.us
+    resources:
+      - ingressroutes
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - metrics.k8s.io
     resources:
       - nodes


### PR DESCRIPTION
To support https://github.com/benphelps/homepage/pull/1161

This adds permissions to the Homepage ClusterRole to be able to read Traefik IngressRoutes for annotations. 