### PR TITLE
Adding traefik.io API group to RBAC template

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: Chart for benphelps homepage
 icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
-version: 1.2.0
+version: 1.2.1
 appVersion: v0.6.10
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage

--- a/charts/homepage/templates/rbac.yaml
+++ b/charts/homepage/templates/rbac.yaml
@@ -43,6 +43,7 @@ rules:
       - list
   - apiGroups:
       - traefik.containo.us
+      - traefik.io
     resources:
       - ingressroutes
     verbs:


### PR DESCRIPTION
In [Traefik 2.10](https://doc.traefik.io/traefik/migration/v2/#kubernetes-crds) they want to deprecate `traefik.containo.us` in favor of the `traefik.io` API group. If anyone tries to run version `1.2.0` of the chart this will throw a:
```shell
ingressroutes.traefik.io is forbidden: User "system:serviceaccount:default:homepage" cannot list resource "ingressroutes" in API group "traefik.io" at the cluster scope'
```
This PR only adds the additional API group to the ClusterRole