### PR TITLE
added rbac for crd check

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: Chart for benphelps homepage
 icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
-version: 1.2.1
+version: 1.2.2
 appVersion: v0.6.10
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage

--- a/charts/homepage/templates/rbac.yaml
+++ b/charts/homepage/templates/rbac.yaml
@@ -57,6 +57,12 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Hey!

I've created a MR on the homepage repo (https://github.com/benphelps/homepage/pull/2003) which adds a feature to check if the traefik (or more in the future) crd's are available on the cluster. If not the evaluation code for them will not be executed. 
In order to have the permissions to check if a crd exists we would have to extend the permissions of the cluster role. Otherwise a new error would be logged. For details of the implementation please see the linked MR. 

In the future we could then make the traefik apiGroups optional in the rbac.yaml template and introduce a switch in the values.yaml to only roll out permissions if they are really needed, but for now I'll would like to keep it simple. 

Cheers!