### PR TITLE
update Homepage repo; upgrade default to v0.8.3

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 description: Chart for benphelps homepage
 icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
-version: 1.2.3
-appVersion: v0.6.10
+version: 1.2.4
+appVersion: v0.8.3
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage
   - https://github.com/benphelps/homepage/

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/benphelps/homepage
+  repository: ghcr.io/gethomepage/homepage
   # tag: v0.6.0
 
 # Enable RBAC. RBAC is necessary to use Kubernetes integration


### PR DESCRIPTION
Currently the Helm chart defaults to an old version of the container using an outdated GH repo URL. This fixes both of those issues, defaulting to v0.8.3 in the new GH org.