### PR TITLE
Homepage maintenance: move to new repo, upgrade to latest version

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -1,13 +1,13 @@
 ---
 apiVersion: v2
-description: Chart for benphelps homepage
-icon: https://github.com/benphelps/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
+description: Chart for gethomepage/homepage
+icon: https://github.com/gethomepage/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
 version: 1.2.3
 appVersion: v0.6.10
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage
-  - https://github.com/benphelps/homepage/
+  - https://github.com/gethomepage/homepage/
 maintainers:
   - name: jameswynn
 dependencies:

--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -4,7 +4,7 @@ description: Chart for gethomepage/homepage
 icon: https://github.com/gethomepage/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
 version: 1.2.3
-appVersion: v0.6.10
+appVersion: v0.8.8
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage
   - https://github.com/gethomepage/homepage/

--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: Chart for gethomepage/homepage
 icon: https://github.com/gethomepage/homepage/blob/de584eae8f12a0d257e554e9511ef19bd2a1232c/public/mstile-150x150.png
 name: homepage
-version: 1.2.3
+version: 2.0.0
 appVersion: v0.8.8
 sources:
   - https://github.com/jameswynn/helm-charts/charts/homepage

--- a/charts/homepage/readme.md
+++ b/charts/homepage/readme.md
@@ -1,8 +1,8 @@
-# Homepage (benphelps)
+# Homepage ([gethomepage.dev](https://gethomepage.dev/))
 
 A modern (fully static, fast), secure (fully proxied), highly customizable application dashboard with integrations for more than 25 services and translations for over 15 languages. Easily configured via YAML files (or discovery via docker labels).
 
-[Homepage](https://github.com/benphelps/homepage)
+[Homepage](https://github.com/gethomepage/homepage)
 
 ## TL;DR
 
@@ -13,7 +13,7 @@ helm install my-release jameswynn/homepage
 
 ## Introduction
 
-This chart bootstraps a [Homepage](https://github.com/benphelps/homepage) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Homepage](https://github.com/gethomepage/homepage) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/gethomepage/homepage
-  # tag: v0.6.0
+  # tag: v0.8.8
 
 # Enable RBAC. RBAC is necessary to use Kubernetes integration
 enableRbac: false

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/benphelps/homepage
+  repository: ghcr.io/gethomepage/homepage
   # tag: v0.6.0
 
 # Enable RBAC. RBAC is necessary to use Kubernetes integration


### PR DESCRIPTION
This is kind of a duplicate of https://github.com/jameswynn/helm-charts/pull/17 (_albeit a bit more complete IMO_)

There's 3 maintenance items here:
 - moving to the new Homepage org repo (see https://gethomepage.dev/main/more/homepage-move/)
 - bump the app to its latest version (from v0.6.10 to v0.8.8 – including breaking changes documented here when bumping to v0.8.0: https://github.com/gethomepage/homepage/releases/tag/v0.8.0)
 - bump the chart version to 2.0.0, reflecting the breaking change