### PR TITLE
Add better support for gateway api HttpRoute discovery.

### DIFF
--- a/charts/homepage/templates/_rbac.yaml
+++ b/charts/homepage/templates/_rbac.yaml
@@ -39,6 +39,14 @@ rules:
       - get
       - list
   - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+      - gateways
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - metrics.k8s.io
     resources:
       - nodes

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -106,6 +106,8 @@ config:
   kubernetes:
     # change mode to 'cluster' to use RBAC service account
     mode: disable
+    # Uncomment to enable gateway api HttpRoute discovery.
+    #gateway: true
   docker:
   settings:
 


### PR DESCRIPTION
- Adds the required RBAC permissions.
- Update values with a comment on how to enable gateway api discovery.

See [recent addition in homepage](https://github.com/gethomepage/homepage/commit/91d5fc8e428b7372f097e2be0ddfe84478027331#diff-ddd209b0dc9802f753746d182519a82dabdd676c02090abd243f2f14d6f758bd) for gateway api support.